### PR TITLE
Removed the disabling of SPI macro that was added, should be leverage…

### DIFF
--- a/src/DpsClass.h
+++ b/src/DpsClass.h
@@ -15,7 +15,6 @@
 #define DPSCLASS_H_INCLUDED
 
 #include <Arduino.h>
-#define DPS_DISABLESPI
 #ifndef DPS_DISABLESPI
 #include <SPI.h>
 #endif


### PR DESCRIPTION
…d as a build flag.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

**Description**

Removed `#define DPS_DISABLESPI` from **DpsClass.h**.

**Context**

The addition of `#define DPS_DISABLESPI` breaks SPI usage. That flag should be added as a build flag anyway, not a direct addition to the src.