### PR TITLE
fix issue breaking i2c interrupt

### DIFF
--- a/src/Dps3xx.cpp
+++ b/src/Dps3xx.cpp
@@ -11,17 +11,17 @@ int16_t Dps3xx::getContResults(float *tempBuffer,
     return DpsClass::getContResults(tempBuffer, tempCount, prsBuffer, prsCount, registers[FIFO_EMPTY]);
 }
 
-#ifndef DPS_DISABLESPI
 int16_t Dps3xx::setInterruptSources(uint8_t intr_source, uint8_t polarity)
 {
+    #ifndef DPS_DISABLESPI
     // Interrupts are not supported with 4 Wire SPI
     if (!m_SpiI2c & !m_threeWire)
     {
         return DPS__FAIL_UNKNOWN;
     }
+    #endif
     return writeByteBitfield(intr_source, registers[INT_SEL]) || writeByteBitfield(polarity, registers[INT_HL]);
 }
-#endif
 
 void Dps3xx::init(void)
 {

--- a/src/DpsClass.h
+++ b/src/DpsClass.h
@@ -14,6 +14,10 @@
 #ifndef DPSCLASS_H_INCLUDED
 #define DPSCLASS_H_INCLUDED
 
+#if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_PSOC6)
+#define DPS_DISABLESPI
+#endif
+
 #include <Arduino.h>
 #ifndef DPS_DISABLESPI
 #include <SPI.h>


### PR DESCRIPTION
When `DPS_DISABLESPI` is defined there is no function `Dps3xx::setInterruptSources(unsigned char, unsigned char)` available. This breaks interrupt functionality also in I2C mode.

This PR makes the function available in I2C mode.